### PR TITLE
Add missing CSRF_TRUSTED_URLS environment variable to example docker-compose files 

### DIFF
--- a/examples/normal/docker-compose.yml
+++ b/examples/normal/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - MYSQL_HOST=nearbeach-db
       - ADMIN_USERNAME=
       - ADMIN_EMAIL=
+      - CSRF_TRUSTED_URLS=https://nearbeach.example.com
     volumes:
       - .:/ceansuite
     ports:

--- a/examples/traefik/docker-compose.yml
+++ b/examples/traefik/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - MYSQL_HOST=nearbeach-db
       - ADMIN_USERNAME=aidan
       - ADMIN_EMAIL=aidan@example.com
+      - CSRF_TRUSTED_URLS=https://nearbeach.example.com
     volumes:
       - .:/ceansuite
     ports:


### PR DESCRIPTION
In this pull request, I added the missing CSRF_TRUSTED_URLS environment variable to example docker-compose files.