### PR TITLE
add docker compose sample with external minio

### DIFF
--- a/examples/minio-ext/docker-compose.minio.yaml
+++ b/examples/minio-ext/docker-compose.minio.yaml
@@ -1,0 +1,18 @@
+version: '3'
+
+networks:
+  # thing to note is that it seems network referenced externally is prefix by folder name
+  minio-ext_backend:
+    external: true
+
+services:
+  minio:
+    image: 'bitnami/minio:latest'
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    environment:
+      - MINIO_ROOT_USER=minio-root-user
+      - MINIO_ROOT_PASSWORD=minio-root-password
+    networks:
+      - minio-ext_backend

--- a/examples/minio-ext/docker-compose.yaml
+++ b/examples/minio-ext/docker-compose.yaml
@@ -1,0 +1,57 @@
+version: '3'
+
+services:
+    db:
+        image: mariadb:10.11
+        container_name: nearbeach-db
+        networks:
+          - backend
+        ports:
+        - 3306:3306
+        environment:
+        - MARIADB_DATABASE=<<Please fill>>
+        - MARIADB_USER=<<Please fill>>
+        - MARIADB_PASSWORD=<<Please fill>>
+        - MARIADB_ROOT_PASSWORD=<<Please fill>>
+        volumes:
+        - ./init:/docker-entrypoint-initdb.d
+    nearbeach:
+        image: robotichead/nearbeach:latest
+        container_name: nearbeach
+        networks:
+          - backend
+        environment:
+        - SECRET_KEY=<<Please fill>>
+        - SMTP_EMAIL_HOST=<<Please fill>>
+        - SMTP_EMAIL_PORT=<<Please fill>>
+        - SMTP_EMAIL_HOST_USER=<<Please fill>>
+        - SMTP_EMAIL_HOST_PASSWORD=<<Please fill>>
+        - DB_DATABASE=<<Please fill>>
+        - DB_USER=<<Please fill>>
+        - DB_PASSWORD=<<Please fill>>
+        - DB_HOST=nearbeach-db
+        - DB_ENGINE=mysql
+        - DB_PORT=3306
+        - ADMIN_USERNAME=<<Please fill>>
+        - ADMIN_EMAIL=<<Please fill>>
+        - ALLOWED_HOSTS=<<yourdomain.com.au>>
+        - CSRF_TRUSTED_URLS=<<https://yourdomain.com.au>>
+        - AZURE_STORAGE_CONNECTION_STRING=<<Please fill>>
+        - AZURE_STORAGE_CONTAINER_NAME=<<Please fill>>
+        volumes:
+        - .:/ceansuite
+        ports:
+        - 8000:8000
+        - 2525:2525
+        command: >
+            sh -c "python manage.py wait_for_database &&
+                ls -al &&
+                python manage.py migrate &&
+                python manage.py initadmin &&
+                python manage.py runserver 0.0.0.0:8000"
+        restart: unless-stopped
+        depends_on:
+        - db
+
+networks:
+  backend:

--- a/examples/minio-ext/docker-compose.yaml
+++ b/examples/minio-ext/docker-compose.yaml
@@ -36,8 +36,10 @@ services:
         - ADMIN_EMAIL=<<Please fill>>
         - ALLOWED_HOSTS=<<yourdomain.com.au>>
         - CSRF_TRUSTED_URLS=<<https://yourdomain.com.au>>
-        - AZURE_STORAGE_CONNECTION_STRING=<<Please fill>>
-        - AZURE_STORAGE_CONTAINER_NAME=<<Please fill>>
+        - AWS_ACCESS_KEY_ID=<<Please fill>>
+        - AWS_SECRET_ACCESS_KEY=<<Please fill>>
+        - AWS_STORAGE_BUCKET_NAME=<<Please fill>>
+        - AWS_S3_ENDPOINT_URL=<<Please fill>>
         volumes:
         - .:/ceansuite
         ports:


### PR DESCRIPTION
Follow up from your stream the other night about adding externally minio.

`docker-compose.yaml` is pulled from your website assuming it's up to date.
- first change is to create the network reference at the bottom
- second change updates services to use that new network.

`docker-compose.minio.yaml` is just a sample minio compose file pulled from dockerhub.
- first change adds a reference to external network defined in `docker-compose.yaml`.
- second change updates the minio service to use that external network.


I tested this by runing `docker exec -it <container_id_of_nearbeach> bash` and ran following commands to confirm minio was reachable.
- `wget http://minio-ext-minio-1:9000` should return forbidden error
- `wget http://minio-ext-minio-1:9001` should download the login page i believe