### PR TITLE
Resolves #14: Replaces Deprecated Django Method

### DIFF
--- a/extra/management/commands/initadmin.py
+++ b/extra/management/commands/initadmin.py
@@ -3,15 +3,22 @@ from django.core.management.base import BaseCommand
 # from django.conf import settings
 
 import os
+import string
+import secrets
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
         if User.objects.count() == 0:
             username = os.getenv("ADMIN_USERNAME")
             email = os.getenv("ADMIN_EMAIL")
-            password = User.objects.make_random_password()
+            password = self.generate_initial_password()
             print('Creating account for %s (%s)' % (username, email))
             admin = User.objects.create_superuser(email=email, username=username, password=password)
             admin.is_active = True
             admin.is_admin = True
             admin.save()
+    
+    # from https://docs.python.org/3/library/secrets.html#recipes-and-best-practices
+    def generate_initial_password(self):
+        alpha = string.ascii_letters + string.digits
+        password = ''.join(secrets.choice(alpha) for i in range(16))

--- a/extra/management/commands/initadmin.py
+++ b/extra/management/commands/initadmin.py
@@ -22,3 +22,4 @@ class Command(BaseCommand):
     def generate_initial_password(self):
         alpha = string.ascii_letters + string.digits
         password = ''.join(secrets.choice(alpha) for i in range(16))
+        return password


### PR DESCRIPTION
## Proposed Fix

This PR uses the proposed fix for #14 suggested by [Django here.](https://docs.djangoproject.com/en/4.2/releases/4.2/#id1)

Generates a 16-character random password with Python's `secrets` module.

This still requires the user to change the password upon initialization, but should solve the self-hosted container build from failing.